### PR TITLE
If users email is blank, redirect to "Please Enter your email"

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,7 +10,7 @@ class SessionsController < ApplicationController
     user = User.where(:provider => auth['provider'], 
                       :uid => auth['uid']).first || User.create_with_omniauth(auth)
     session[:user_id] = user.id
-    if !user.email
+    if user.email.blank?
       redirect_to edit_user_path(user), :alert => "Please enter your email address."
     else
       redirect_to root_url, :notice => 'Signed in!'


### PR DESCRIPTION
Did we want to redirect users to the "Please enter your email address" screen if their email was blank? It was in the code but wasn't working. A one word add corrected it. Now it checks if their email is blank, and redirects them accordingly (either "Signed in" or "Please enter your email address")
