### PR TITLE
Add session fixation countermeasure

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,6 +9,10 @@ class SessionsController < ApplicationController
     auth = request.env["omniauth.auth"]
     user = User.where(:provider => auth['provider'], 
                       :uid => auth['uid'].to_s).first || User.create_with_omniauth(auth)
+# Reset the session after successful login, per
+# 2.8 Session Fixation – Countermeasures:
+# http://guides.rubyonrails.org/security.html#session-fixation-countermeasures
+    reset_session
     session[:user_id] = user.id
     if user.email.blank?
       redirect_to edit_user_path(user), :alert => "Please enter your email address."


### PR DESCRIPTION
This invokes reset_session to make a new [session ID](http://guides.rubyonrails.org/security.html#session-id) during a successful login process. This prevents session fixation attacks as described in sections [2.7](http://guides.rubyonrails.org/security.html#session-fixation) and [2.8](http://guides.rubyonrails.org/security.html#session-fixation-countermeasures) of the Ruby On Rails Security Guide.

Attackers using [XSS](http://en.wikipedia.org/wiki/Cross-site_scripting) can set the victim's unlogged-in session cookie on a site to be the same as their own. Thus they are sharing the same session ID and the same session as the victim. Later if they lure the victim to log in, then that session ID is logged in and thus the attacker's computer is logged in too. Then the attacker can perform whatever actions they want as the logged in user. It's a two-step process separated by a considerable time delay.

That kind of attack can be effective unless we change the session ID at each successful login, so that from the moment the victim logs in, the attacker's session ID won't match anymore. This protects the actions your RailsApps users limit to their logged in users.
