### PR TITLE
Add comment explaining how to access earlier versions of MongoDB

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ group :assets do
   gem 'uglifier', '>= 1.0.3'
 end
 gem 'jquery-rails'
+# Per http://mongoid.org/en/mongoid/docs/installation.html#installation
+# to use mongodb versions before 2.2.0, uncomment this line instead:
+# gem 'mongoid', '~> 3.0.1'
 gem "mongoid", ">= 3.1.1"
 gem "rspec-rails", ">= 2.12.2", :group => [:development, :test]
 gem "database_cleaner", ">= 0.9.1", :group => :test


### PR DESCRIPTION
This pull request explains how RailsApps users, if they need to, can use a version of MongoDB earlier than 2.2.0. It explains this by including the Gemfile line they need in a comment.

As of now, the latest backported version of MongoDB, at least for the latest stable version of Debian (obviously a popular server operating system) is MongoDB 2.0.0.

Debian squeeze backports (stable-bpo) runs [MongoDB](http://packages.qa.debian.org/m/mongodb.html) 2.0.0. With MongoDB 2.0.0, the [Mongoid](http://mongoid.org/en/mongoid/docs/installation.html#installation) gem must be version 3.0.x (~> 3.0.1).

It explains in the proper semantic versioning way how to pull from the particular version branch of the Mongoid gem appropriate to these earlier MongoDB versions. It references the Mongoid gem's [installation](http://mongoid.org/en/mongoid/docs/installation.html#installation) documentation.
