### PR TITLE
added created_at to user model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User
   include Mongoid::Document
+  include Mongoid::Timestamps::Created
   field :provider, type: String
   field :uid, type: String
   field :name, type: String


### PR DESCRIPTION
I find that this reference to created_at (https://github.com/RailsApps/rails3-mongoid-omniauth/blob/master/app/views/users/index.html.erb#L5) fails without including the line in this commit
